### PR TITLE
fix: Replace '.storylink' with '.titlelink'

### DIFF
--- a/HNDark Extension/Resources/style.css
+++ b/HNDark Extension/Resources/style.css
@@ -20,7 +20,7 @@
         display: none !important;
     }
 
-    a.storylink {
+    a.titlelink {
         color: #F3F4F6 !important;
     }
 


### PR DESCRIPTION
ycombinator no longer uses the storylink class